### PR TITLE
Dependencies: bump Rubocop to 0.5.1

### DIFF
--- a/jekyll-include-cache.gemspec
+++ b/jekyll-include-cache.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "jekyll", "~> 3.3"
   s.add_development_dependency "rspec", "~> 3.5"
-  s.add_development_dependency "rubocop", "~> 0.43"
+  s.add_development_dependency "rubocop", "~> 0.51"
 end


### PR DESCRIPTION
I forgot to do that in #4 😊 

@benbalter Just to know what actions to take _after_ a Jekyll release, what would you recommend for dependencies bump in plugins?

* Should plugins follow the latest Jekyll version? (We bumped Rubocop to `0.5.1` in `3.6.2`)
* Should we allow bundler to get latest patch releases? (e.g, `0.5` instead of `0.5.1` here)

