### PR TITLE
Docs: the `gems` key is now `plugins`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ If you have a computationally expensive include (such as a sidebar or navigation
 2. Add the following to your site's config file:
 
   ```yml
-  gems:
+  plugins:
     - jekyll-include-cache
   ```
+  💡 If you are using a Jekyll version less than 3.5.0, use the `gems` key instead of `plugins`.
 
 3. Replace `{% include foo.html %}` in your template with `{% include_cached foo.html %}`
 


### PR DESCRIPTION
Update readme.
[Jekyll v3.5](https://jekyllrb.com/news/2017/06/15/jekyll-3-5-0-released/):

> The `gems` key in the `_config.yml` is now `plugins`.


P.S. Thanks for the useful plugin! It save a lot of my CPU time. Why it is not listed in [GitHub Pages dependencies](https://pages.github.com/versions/) (only in https://github.com/github/pages-gem/blob/v172/lib/github-pages/plugins.rb#L40 code)?