### PR TITLE
Cache generated MD5 digests

### DIFF
--- a/lib/jekyll-include-cache/tag.rb
+++ b/lib/jekyll-include-cache/tag.rb
@@ -4,6 +4,10 @@ require "digest/md5"
 
 module JekyllIncludeCache
   class Tag < Jekyll::Tags::IncludeTag
+    def self.digest_cache
+      @digest_cache ||= {}
+    end
+
     def render(context)
       path   = path(context)
       params = parse_params(context) if @params
@@ -28,7 +32,14 @@ module JekyllIncludeCache
     end
 
     def key(path, params)
-      Digest::MD5.hexdigest(path.to_s + params.to_s)
+      path_hash   = path.hash
+      params_hash = params.hash
+      self.class.digest_cache[path_hash] ||= {}
+      self.class.digest_cache[path_hash][params_hash] ||= digest(path_hash, params_hash)
+    end
+
+    def digest(path_hash, params_hash)
+      Digest::MD5.hexdigest("#{path_hash}#{params_hash}")
     end
   end
 end

--- a/spec/jekyll-include-tag/tag_spec.rb
+++ b/spec/jekyll-include-tag/tag_spec.rb
@@ -28,17 +28,21 @@ RSpec.describe JekyllIncludeCache::Tag do
   context "building the key" do
     it "builds the key" do
       key = subject.send(:key, "foo.html", "foo" => "bar", "foo2" => "bar2")
-      expect(key).to eql("19f48d1dba832dec7442c3ed57ecd9ed")
+      expect(key).to eql(
+        subject.send(:digest, "foo.html".hash, { "foo" => "bar", "foo2" => "bar2" }.hash)
+      )
     end
 
     it "builds the key based on the path" do
       key = subject.send(:key, "foo2.html", "foo" => "bar", "foo2" => "bar2")
-      expect(key).to eql("1397798e1ca375c42640615904c18a8c")
+      expect(key).to eql(
+        subject.send(:digest, "foo2.html".hash, { "foo" => "bar", "foo2" => "bar2" }.hash)
+      )
     end
 
     it "builds the key based on the params" do
       key = subject.send(:key, "foo2.html", "foo" => "bar")
-      expect(key).to eql("2e357f2d61c19e041986cb8409cc0e25")
+      expect(key).to eql(subject.send(:digest, "foo2.html".hash, { "foo" => "bar" }.hash))
     end
   end
 


### PR DESCRIPTION
## Summary

* The digest is cached to avoid allocating the same value as different objects when the same tag markup is rendered multiple times.
* Cache is dependent on both the hash-value of the include file's absolute path and the hash-value of any accompanying parameters.
* The hash-values are used because they would be much smaller keys for the cache at all times in comparison to the actual path and the value of `params` which can be a large object in certain situations.
  Additionally, hash-values prevent exposing raw details on inspecting the cache.