### PR TITLE
Use object ids instead of hashes for Jekyll documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ spec/examples.txt
 *.gem
 Gemfile.lock
 /tmp
+vendor/bundle
+.bundle
+.jekyll-cache

--- a/lib/jekyll-include-cache/tag.rb
+++ b/lib/jekyll-include-cache/tag.rb
@@ -43,7 +43,7 @@ module JekyllIncludeCache
 
       md5 = Digest::MD5.new
 
-      params.each do |key, value|
+      params.sort.each do |_, value|
         # Using the fact that Jekyll documents don't change during a build.
         # Instead of calculating the hash of an entire document (expensive!)
         # we just use its object id.

--- a/lib/jekyll-include-cache/tag.rb
+++ b/lib/jekyll-include-cache/tag.rb
@@ -39,7 +39,10 @@ module JekyllIncludeCache
     end
 
     def digest(path_hash, params_hash)
-      Digest::MD5.hexdigest("#{path_hash}#{params_hash}")
+      md5 = Digest::MD5.new
+      md5.update path_hash.to_s
+      md5.update params_hash.to_s
+      md5.hexdigest
     end
   end
 end

--- a/lib/jekyll-include-cache/tag.rb
+++ b/lib/jekyll-include-cache/tag.rb
@@ -44,11 +44,9 @@ module JekyllIncludeCache
       md5 = Digest::MD5.new
 
       params.each do |key, value|
-        # Using the fact that Jekyll documents don't change within a site build.
-        # Instead of calculating the hash of an entire document (expesive!)
-        # we just use the object id.
-        # This allows posts and pages to be passed to `include_cached`
-        # without a performance penality.
+        # Using the fact that Jekyll documents don't change during a build.
+        # Instead of calculating the hash of an entire document (expensive!)
+        # we just use its object id.
         if value.is_a? Jekyll::Drops::Drop
           md5.update value.object_id.to_s
         else

--- a/spec/jekyll-include-tag/tag_spec.rb
+++ b/spec/jekyll-include-tag/tag_spec.rb
@@ -29,20 +29,20 @@ RSpec.describe JekyllIncludeCache::Tag do
     it "builds the key" do
       key = subject.send(:key, "foo.html", "foo" => "bar", "foo2" => "bar2")
       expect(key).to eql(
-        subject.send(:digest, "foo.html".hash, { "foo" => "bar", "foo2" => "bar2" }.hash)
+        subject.send(:digest, "foo.html".hash, subject.send(:quick_hash, { "foo" => "bar", "foo2" => "bar2" }))
       )
     end
 
     it "builds the key based on the path" do
       key = subject.send(:key, "foo2.html", "foo" => "bar", "foo2" => "bar2")
       expect(key).to eql(
-        subject.send(:digest, "foo2.html".hash, { "foo" => "bar", "foo2" => "bar2" }.hash)
+        subject.send(:digest, "foo2.html".hash, subject.send(:quick_hash, { "foo" => "bar", "foo2" => "bar2" }))
       )
     end
 
     it "builds the key based on the params" do
       key = subject.send(:key, "foo2.html", "foo" => "bar")
-      expect(key).to eql(subject.send(:digest, "foo2.html".hash, { "foo" => "bar" }.hash))
+      expect(key).to eql(subject.send(:digest, "foo2.html".hash, subject.send(:quick_hash, { "foo" => "bar" })))
     end
   end
 

--- a/spec/jekyll-include-tag/tag_spec.rb
+++ b/spec/jekyll-include-tag/tag_spec.rb
@@ -28,21 +28,24 @@ RSpec.describe JekyllIncludeCache::Tag do
   context "building the key" do
     it "builds the key" do
       key = subject.send(:key, "foo.html", "foo" => "bar", "foo2" => "bar2")
+      params = { "foo" => "bar", "foo2" => "bar2" }
       expect(key).to eql(
-        subject.send(:digest, "foo.html".hash, subject.send(:quick_hash, { "foo" => "bar", "foo2" => "bar2" }))
+        subject.send(:digest, "foo.html".hash, subject.send(:quick_hash, params))
       )
     end
 
     it "builds the key based on the path" do
       key = subject.send(:key, "foo2.html", "foo" => "bar", "foo2" => "bar2")
+      params = { "foo" => "bar", "foo2" => "bar2" }
       expect(key).to eql(
-        subject.send(:digest, "foo2.html".hash, subject.send(:quick_hash, { "foo" => "bar", "foo2" => "bar2" }))
+        subject.send(:digest, "foo2.html".hash, subject.send(:quick_hash, params))
       )
     end
 
     it "builds the key based on the params" do
       key = subject.send(:key, "foo2.html", "foo" => "bar")
-      expect(key).to eql(subject.send(:digest, "foo2.html".hash, subject.send(:quick_hash, { "foo" => "bar" })))
+      params = { "foo" => "bar" }
+      expect(key).to eql(subject.send(:digest, "foo2.html".hash, subject.send(:quick_hash, params)))
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ end
 
 Jekyll.logger.adjust_verbosity(:quiet => true)
 
-Jekyll::Cache.base_dir = File.expand_path("../tmp", __dir__) if defined? Jekyll::Cache
+Jekyll::Cache.cache_dir = File.expand_path("../tmp", __dir__) if defined? Jekyll::Cache
 
 def fixture_path(fixture)
   File.expand_path "./fixtures/#{fixture}", File.dirname(__FILE__)


### PR DESCRIPTION
Proposed solution for #16.

This change drastically improves performance when passing posts, documents or pages, e.g.

```
{% for post of site.posts %}
  {% included_cached post.html post=post %}
{% endfor %}
```

The problem with doing the above is the long time it takes to calculate the `.hash` of a large Jekyll document, such as a post.

However, it should be safe to assume that documents don't change during a page build, so using the `object_id` instead of the `hash` for comparison results in a *large* performance boost. 

The implementation only applies to known Jekyll types, so that other complex data still get the old treatment, e.g.

```
---
data:
  a: 3
  b: 4
---
{% include_cached partial.html data=page.data %}
```

still works, even if `data` is passed in multiple places with different object ids.

