### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     time: "10:00"
     timezone: US/Eastern
   open-pull-requests-limit: 99
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+    timezone: US/Eastern
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Adds a `github-actions` update entry to `.github/dependabot.yml` so workflow action versions are kept current, matching the config already used in `jekyll-remote-theme`. Schedule mirrors this repo's existing bundler entry (daily).

🤖 Generated with [Claude Code](https://claude.com/claude-code)