### PR TITLE
Modernize CI matrix; fix main (rubocop-rspec 3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,27 +4,37 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0']
-        jekyll-version: ["~> 3.0", "~> 4.0"]
+        ruby_version:
+          - "3.3"
+          - "4.0"
+        jekyll_version:
+          - "~> 3.0"
+          - "~> 4.0"
+        exclude:
+          # Jekyll 3.x is not compatible with Ruby 4.0; GitHub Pages still
+          # ships Jekyll 3.x, so keep testing it on the newest Ruby that
+          # supports it (3.3).
+          - ruby_version: "4.0"
+            jekyll_version: "~> 3.0"
+
+    env:
+      JEKYLL_VERSION: ${{ matrix.jekyll_version }}
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
-        env:
-          JEKYLL_VERSION: ${{ matrix.jekyll-version }}
+    - name: Set up Ruby ${{ matrix.ruby_version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true # Runs bundle install and caches installed gems
 
-      - name: Run tests
-        run: script/cibuild
+    - name: Run tests
+      run: script/cibuild

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,9 +23,9 @@ RSpec/ContextWording:
     - 'spec/jekyll-include-tag_spec.rb'
 
 # Offense count: 3
-# Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
+# Configuration parameters: Include, CustomTransform, IgnoreMethods.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
   Exclude:
     - 'spec/jekyll-include-tag/cache_spec.rb'
     - 'spec/jekyll-include-tag/tag_spec.rb'

--- a/jekyll-include-cache.gemspec
+++ b/jekyll-include-cache.gemspec
@@ -22,4 +22,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop-jekyll", "~> 0.3"
   s.add_development_dependency "rubocop-performance", "~> 1.5"
   s.add_development_dependency "rubocop-rspec", "~> 3.0"
+  # No longer default gems as of recent Rubies; required transitively by
+  # RuboCop and Jekyll's dependencies (e.g. safe_yaml needs base64 on Ruby
+  # 3.4+, RuboCop needs benchmark/ostruct on Ruby 4.0).
+  s.add_development_dependency "base64"
+  s.add_development_dependency "benchmark"
+  s.add_development_dependency "ostruct"
+  s.add_development_dependency "tsort"
 end

--- a/spec/jekyll-include-tag/cache_spec.rb
+++ b/spec/jekyll-include-tag/cache_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe JekyllIncludeCache::Cache do
 
   it "sets" do
     subject["foo2"] = "bar2"
-    cache = subject.instance_variable_get("@cache")
+    cache = subject.instance_variable_get(:@cache)
     expect(cache["foo2"]).to eql("bar2")
   end
 
@@ -32,7 +32,7 @@ RSpec.describe JekyllIncludeCache::Cache do
   it "clears" do
     expect(subject.key?("foo")).to be_truthy
     subject.clear
-    cache = subject.instance_variable_get("@cache")
+    cache = subject.instance_variable_get(:@cache)
     expect(cache).to eql({})
   end
 


### PR DESCRIPTION
Modernizes the test matrix and **fixes the currently-red `main`**.

## Fixes main
`main` went red after the rubocop-rspec `~> 3.0` bump (#25): rubocop-rspec 3.0 split `RSpec/FilePath` into `RSpec/SpecFilePathFormat`/`RSpec/SpecFilePathSuffix`, so the stale `.rubocop_todo.yml` entry errors out `script/cibuild`. Renamed the cop.

## Modernize matrix
- Ruby **3.3 + 4.0** against Jekyll **3.x + 4.x** (drop EOL 2.7/3.0); exclude Ruby 4.0 + Jekyll 3.x (incompatible; GH Pages still ships Jekyll 3.x so it's kept on Ruby 3.3).
- `actions/checkout` v2 → v4; add `fail-fast: false`.
- Move `JEKYLL_VERSION` to a **job-level env** so it reaches the `bundle install` (setup-ruby) step — previously scoped to the wrong step.

## Make Ruby 4.0 pass
- gemspec: add `base64`/`benchmark`/`ostruct`/`tsort` dev deps (no longer default gems on Ruby 4.0; needed by RuboCop and Jekyll's deps).
- Autocorrect `Performance/StringIdentifierArgument` in `cache_spec`.

**Verified:** `script/cibuild` green on Ruby 4.0.6 + Jekyll `~> 4.0`.

> Note: the branch-protection required-check contexts will be repointed to the new job names (`test (3.3, ~> 3.0)`, `test (3.3, ~> 4.0)`, `test (4.0, ~> 4.0)`) as part of merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)