### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.2.2
+
+Maintenance release: no runtime behavior changes.
+
+### Infrastructure
+
+- Modernize CI — test Ruby 3.3 & 4.0 against Jekyll 3.x & 4.x, and fix the
+  build under rubocop-rspec 3.0 (#30)
+- Bump rubocop-rspec to `~> 3.0` (#25)
+- Enable Dependabot for GitHub Actions; bump `actions/checkout` and
+  `github/codeql-action` (#27, #28, #29)
+- Add CodeQL analysis workflow
+
+### Misc
+
+- Fix a spelling mistake (#24)

--- a/lib/jekyll-include-cache/version.rb
+++ b/lib/jekyll-include-cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllIncludeCache
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Prepares **v0.2.2** (patch, maintenance). Adds a `CHANGELOG.md` (none existed). Publish is a manual `gem push` after merge.

**Bump:** 0.2.1 → 0.2.2

### Changelog
**Infrastructure**
- Modernize CI — Ruby 3.3 & 4.0 × Jekyll 3.x & 4.x; fix build under rubocop-rspec 3.0 (#30)
- Bump rubocop-rspec to `~> 3.0` (#25)
- Enable Dependabot for GitHub Actions; bump `actions/checkout` and `github/codeql-action` (#27, #28, #29)
- Add CodeQL analysis workflow

**Misc**
- Fix a spelling mistake (#24)

_Patch: maintenance only, no runtime behavior changes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)